### PR TITLE
Consensus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ rand = { version = "0.7.2", features = ["small_rng"] }
 quickcheck = "0.9.0"
 quickcheck_macros = "0.8.0"
 itertools = "0.8.2"
+arraymap = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,21 @@ keywords = ["p3p", "pnp", "slam", "vision"] # up to 5 keywords
 categories = ["science::robotics", "multimedia::video"] # up to 5 categories, cf crates.io/category_slugs
 license = "MPL-2.0" # SPDX license
 
+[package.metadata.docs.rs]
+rustdoc-args = [ "--html-in-header", "katex-header.html" ]
+
+[features]
+default = []
+consensus = ["sample-consensus"]
+
+[dependencies]
+sample-consensus = { version = "0.1.0", optional = true }
+
 [dependencies.nalgebra]
 version = "0.18.1"
 default-features = false
-# features = []
 
 [dev-dependencies]
 approx = "0.3"
-quickcheck = "0.8"
-quickcheck_macros = "0.8"
-
-[package.metadata.docs.rs]
-rustdoc-args = [ "--html-in-header", "katex-header.html" ]
+arrsac = "0.1.0"
+rand = { version = "0.7.2", features = ["small_rng"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,6 @@ default-features = false
 approx = "0.3"
 arrsac = "0.1.0"
 rand = { version = "0.7.2", features = ["small_rng"] }
+quickcheck = "0.9.0"
+quickcheck_macros = "0.8.0"
+itertools = "0.8.2"

--- a/src/nordberg.rs
+++ b/src/nordberg.rs
@@ -18,10 +18,13 @@ mod consensus;
 #[cfg(feature = "consensus")]
 pub use consensus::*;
 
-use nalgebra::{Isometry3, Matrix3, Quaternion, Translation, UnitQuaternion, Vector3, Vector4};
+use nalgebra::{
+    Isometry3, Matrix3, Quaternion, Translation, UnitQuaternion, Vector2, Vector3, Vector4,
+};
 
 type Iso3 = Isometry3<f32>;
 type Mat3 = Matrix3<f32>;
+type Vec2 = Vector2<f32>;
 type Vec3 = Vector3<f32>;
 type Vec4 = Vector4<f32>;
 
@@ -571,9 +574,16 @@ mod tests {
         let p3_2d = Vector2::new(p3_cam[0], p3_cam[1]);
         let p2ds = [p1_2d, p2_2d, p3_2d];
 
+        // Stop if points are colinear.
+        for (a, b, c) in p2ds.iter().tuple_combinations() {
+            if ((a - b).normalize()).dot(&(a - c).normalize()) > 1.0 - 10.0 * EPSILON_APPROX {
+                return true;
+            }
+        }
+
         // Stop if the keypoint's location on the frame is too close.
-        for (a, b) in p2ds.iter().cartesian_product(&p2ds) {
-            if (a - b).norm() < EPSILON_APPROX {
+        for (a, b) in p2ds.iter().tuple_combinations() {
+            if (a - b).norm() < 10.0 * EPSILON_APPROX {
                 return true;
             }
         }

--- a/src/nordberg/consensus.rs
+++ b/src/nordberg/consensus.rs
@@ -1,0 +1,33 @@
+use crate::nordberg::{Pose, Sample};
+use sample_consensus::{Estimator, Model};
+
+impl Model for Pose {
+    type Data = Sample;
+
+    fn residual(&self, data: &Self::Data) -> f32 {
+        self.error(data)
+    }
+}
+
+/// This implements the [`sample_consensus::Estimator`] trait.
+///
+/// This uses the algorithm from the paper
+/// "Lambda Twist: An Accurate Fast Robust Perspective Three Point (P3P) Solver"
+/// to estimate four potential poses for the p3p problem.
+pub struct NordbergEstimator;
+
+impl Estimator for NordbergEstimator {
+    type Model = Pose;
+    type ModelIter = Vec<Pose>;
+    const MIN_SAMPLES: usize = 3;
+    fn estimate<'a, I>(&self, mut data: I) -> Self::ModelIter
+    where
+        I: Iterator<Item = &'a Sample> + Clone,
+    {
+        crate::nordberg::solve([
+            data.next().unwrap().clone(),
+            data.next().unwrap().clone(),
+            data.next().unwrap().clone(),
+        ])
+    }
+}

--- a/tests/consensus.rs
+++ b/tests/consensus.rs
@@ -1,0 +1,53 @@
+#![cfg(feature = "consensus")]
+use approx::assert_relative_eq;
+use arrsac::{Arrsac, Config};
+use nalgebra::{Isometry3, Point3, Translation, UnitQuaternion, Vector3};
+use p3p::nordberg::{NordbergEstimator, Sample};
+use rand::{rngs::SmallRng, SeedableRng};
+use sample_consensus::Consensus;
+
+const EPSILON_APPROX: f32 = 1e-2;
+
+fn sample_conv(point: [f32; 3], bearing: [f32; 3]) -> Sample {
+    Sample { point, bearing }
+}
+
+#[test]
+fn arrsac() {
+    let mut arrsac = Arrsac::new(Config::new(0.01), SmallRng::from_seed([0; 16]));
+
+    // Define some points in camera coordinates (with z > 0).
+    let p1_cam = [-0.228_125, -0.061_458_334, 1.0];
+    let p2_cam = [0.418_75, -0.581_25, 2.0];
+    let p3_cam = [1.128_125, 0.878_125, 3.0];
+    let p4_cam = [-0.128_125, 0.578_125, 1.5];
+
+    // Define the camera pose.
+    let rot = UnitQuaternion::from_euler_angles(0.1, 0.2, 0.3);
+    let trans = Translation::from(Vector3::new(0.1, 0.2, 0.3));
+    let pose = Isometry3::from_parts(trans, rot);
+
+    // Compute world coordinates.
+    let p1_world = (pose.inverse() * Point3::from(p1_cam)).coords.into();
+    let p2_world = (pose.inverse() * Point3::from(p2_cam)).coords.into();
+    let p3_world = (pose.inverse() * Point3::from(p3_cam)).coords.into();
+    let p4_world = (pose.inverse() * Point3::from(p4_cam)).coords.into();
+
+    let samples = [
+        sample_conv(p1_world, p1_cam),
+        sample_conv(p2_world, p2_cam),
+        sample_conv(p3_world, p3_cam),
+        sample_conv(p4_world, p4_cam),
+    ];
+
+    // Estimate potential poses with P3P.
+    // Arrsac should use the fourth point to filter and find only one model from the 4 generated.
+    let pose = arrsac
+        .model(&NordbergEstimator, &samples)
+        .unwrap()
+        .to_iso3();
+
+    // Compare the pose to ground truth.
+    assert_relative_eq!(rot, pose.rotation, epsilon = EPSILON_APPROX);
+    assert_relative_eq!(trans, pose.translation, epsilon = EPSILON_APPROX);
+}

--- a/tests/consensus.rs
+++ b/tests/consensus.rs
@@ -10,8 +10,8 @@ use sample_consensus::Consensus;
 
 const EPSILON_APPROX: f32 = 1e-2;
 
-fn sample_conv(point: [f32; 3], bearing: [f32; 3]) -> Sample {
-    Sample { point, bearing }
+fn sample_conv(world: [f32; 3], camera: [f32; 3]) -> Sample {
+    Sample { world, camera }
 }
 
 #[test]

--- a/tests/consensus.rs
+++ b/tests/consensus.rs
@@ -1,8 +1,10 @@
 #![cfg(feature = "consensus")]
-use approx::assert_relative_eq;
+use approx::{assert_relative_eq, relative_eq};
 use arrsac::{Arrsac, Config};
-use nalgebra::{Isometry3, Point3, Translation, UnitQuaternion, Vector3};
+use itertools::Itertools;
+use nalgebra::{Isometry3, Point3, Translation, UnitQuaternion, Vector2, Vector3};
 use p3p::nordberg::{NordbergEstimator, Sample};
+use quickcheck_macros::quickcheck;
 use rand::{rngs::SmallRng, SeedableRng};
 use sample_consensus::Consensus;
 
@@ -50,4 +52,62 @@ fn arrsac() {
     // Compare the pose to ground truth.
     assert_relative_eq!(rot, pose.rotation, epsilon = EPSILON_APPROX);
     assert_relative_eq!(trans, pose.translation, epsilon = EPSILON_APPROX);
+}
+
+type V3 = (f32, f32, f32);
+
+/// This test is ignored because it is random and may fail in CI.
+/// Run `cargo test -- --ignored` to test it.
+#[quickcheck]
+fn non_degenerate_case(rot: V3, trans: V3, p1: V3, p2: V3, p3: V3, p4: V3) -> bool {
+    let mut arrsac = Arrsac::new(Config::new(0.01), SmallRng::from_seed([0; 16]));
+
+    // Use EPSILON_APPROX to force minimum distance.
+    let p1_cam = [p1.0, p1.1, EPSILON_APPROX + p1.2.abs()];
+    let p2_cam = [p2.0, p2.1, EPSILON_APPROX + p2.2.abs()];
+    let p3_cam = [p3.0, p3.1, EPSILON_APPROX + p3.2.abs()];
+    let p4_cam = [p4.0, p4.1, EPSILON_APPROX + p4.2.abs()];
+
+    // 2d keypoints
+    let p1_2d = Vector2::new(p1_cam[0], p1_cam[1]);
+    let p2_2d = Vector2::new(p2_cam[0], p2_cam[1]);
+    let p3_2d = Vector2::new(p3_cam[0], p3_cam[1]);
+    let p4_2d = Vector2::new(p4_cam[0], p4_cam[1]);
+    let p2ds = [p1_2d, p2_2d, p3_2d, p4_2d];
+
+    // Stop if the keypoint's location on the frame is too close.
+    for (a, b) in p2ds.iter().cartesian_product(&p2ds) {
+        if (a - b).norm() < EPSILON_APPROX {
+            return true;
+        }
+    }
+
+    // Define the camera pose.
+    let rotation = UnitQuaternion::from_euler_angles(rot.0, rot.1, rot.2);
+    let translation = Translation::from(Vector3::new(trans.0, trans.1, trans.2));
+    let pose = Isometry3::from_parts(translation, rotation);
+
+    // Compute world coordinates.
+    let p1_world = (pose.inverse() * Point3::from(p1_cam)).coords.into();
+    let p2_world = (pose.inverse() * Point3::from(p2_cam)).coords.into();
+    let p3_world = (pose.inverse() * Point3::from(p3_cam)).coords.into();
+    let p4_world = (pose.inverse() * Point3::from(p4_cam)).coords.into();
+
+    let samples = [
+        sample_conv(p1_world, p1_cam),
+        sample_conv(p2_world, p2_cam),
+        sample_conv(p3_world, p3_cam),
+        sample_conv(p4_world, p4_cam),
+    ];
+
+    // Estimate potential poses with P3P.
+    // Arrsac should use the fourth point to filter and find only one model from the 4 generated.
+    let pose = arrsac
+        .model(&NordbergEstimator, &samples)
+        .unwrap()
+        .to_iso3();
+
+    // Compare the pose to ground truth.
+    relative_eq!(rotation, pose.rotation, epsilon = EPSILON_APPROX)
+        && relative_eq!(translation, pose.translation, epsilon = EPSILON_APPROX)
 }

--- a/tests/consensus.rs
+++ b/tests/consensus.rs
@@ -19,10 +19,10 @@ fn arrsac() {
     let mut arrsac = Arrsac::new(Config::new(0.01), SmallRng::from_seed([0; 16]));
 
     // Define some points in camera coordinates (with z > 0).
-    let p1_cam = [-0.228_125, -0.061_458_334, 1.0];
-    let p2_cam = [0.418_75, -0.581_25, 2.0];
-    let p3_cam = [1.128_125, 0.878_125, 3.0];
-    let p4_cam = [-0.128_125, 0.578_125, 1.5];
+    let p1_cam = [-20.228_125, -0.061_458_334, 1.0];
+    let p2_cam = [-50.418_75, -0.581_25, 2.0];
+    let p3_cam = [1.128_125, 5.878_125, 3.0];
+    let p4_cam = [-0.128_125, 0.578_125, 40.5];
 
     // Define the camera pose.
     let rot = UnitQuaternion::from_euler_angles(0.1, 0.2, 0.3);
@@ -60,7 +60,10 @@ type V3 = (f32, f32, f32);
 /// Run `cargo test -- --ignored` to test it.
 #[quickcheck]
 fn non_degenerate_case(rot: V3, trans: V3, p1: V3, p2: V3, p3: V3, p4: V3) -> bool {
-    let mut arrsac = Arrsac::new(Config::new(0.01), SmallRng::from_seed([0; 16]));
+    let mut arrsac = Arrsac::new(
+        Config::new(0.01).max_candidate_hypotheses(10),
+        SmallRng::from_seed([0; 16]),
+    );
 
     // Use EPSILON_APPROX to force minimum distance.
     let p1_cam = [p1.0, p1.1, EPSILON_APPROX + p1.2.abs()];
@@ -76,7 +79,7 @@ fn non_degenerate_case(rot: V3, trans: V3, p1: V3, p2: V3, p3: V3, p4: V3) -> bo
     let p2ds = [p1_2d, p2_2d, p3_2d, p4_2d];
 
     // Stop if the keypoint's location on the frame is too close.
-    for (a, b) in p2ds.iter().cartesian_product(&p2ds) {
+    for (a, b) in p2ds.iter().tuple_combinations() {
         if (a - b).norm() < EPSILON_APPROX {
             return true;
         }

--- a/tests/consensus.rs
+++ b/tests/consensus.rs
@@ -1,28 +1,30 @@
 #![cfg(feature = "consensus")]
-use approx::{assert_relative_eq, relative_eq};
+use approx::assert_relative_eq;
+use arraymap::ArrayMap;
 use arrsac::{Arrsac, Config};
-use itertools::Itertools;
-use nalgebra::{Isometry3, Point3, Translation, UnitQuaternion, Vector2, Vector3};
+use nalgebra::{Isometry3, Point3, Translation, UnitQuaternion, Vector3};
 use p3p::nordberg::{NordbergEstimator, Sample};
-use quickcheck_macros::quickcheck;
 use rand::{rngs::SmallRng, SeedableRng};
 use sample_consensus::Consensus;
 
 const EPSILON_APPROX: f32 = 1e-2;
 
-fn sample_conv(world: [f32; 3], camera: [f32; 3]) -> Sample {
+fn sample_conv(world: [f32; 3], camera: [f32; 2]) -> Sample {
     Sample { world, camera }
 }
 
 #[test]
-fn arrsac() {
+fn arrsac_manual() {
     let mut arrsac = Arrsac::new(Config::new(0.01), SmallRng::from_seed([0; 16]));
 
     // Define some points in camera coordinates (with z > 0).
-    let p1_cam = [-20.228_125, -0.061_458_334, 1.0];
-    let p2_cam = [-50.418_75, -0.581_25, 2.0];
-    let p3_cam = [1.128_125, 5.878_125, 3.0];
-    let p4_cam = [-0.128_125, 0.578_125, 40.5];
+    let camera_depth_points = [
+        [-0.228_125, -0.061_458_334, 1.0],
+        [0.418_75, -0.581_25, 2.0],
+        [1.128_125, 0.878_125, 3.0],
+        [-0.528_125, 0.178_125, 2.5],
+    ]
+    .map(|&p| Point3::from(p));
 
     // Define the camera pose.
     let rot = UnitQuaternion::from_euler_angles(0.1, 0.2, 0.3);
@@ -30,17 +32,16 @@ fn arrsac() {
     let pose = Isometry3::from_parts(trans, rot);
 
     // Compute world coordinates.
-    let p1_world = (pose.inverse() * Point3::from(p1_cam)).coords.into();
-    let p2_world = (pose.inverse() * Point3::from(p2_cam)).coords.into();
-    let p3_world = (pose.inverse() * Point3::from(p3_cam)).coords.into();
-    let p4_world = (pose.inverse() * Point3::from(p4_cam)).coords.into();
+    let world_points = camera_depth_points.map(|p| pose.inverse() * p);
 
-    let samples = [
-        sample_conv(p1_world, p1_cam),
-        sample_conv(p2_world, p2_cam),
-        sample_conv(p3_world, p3_cam),
-        sample_conv(p4_world, p4_cam),
-    ];
+    // Compute normalized image coordinates.
+    let normalized_image_coordinates = camera_depth_points.map(|p| (p / p.z).xy());
+
+    let samples: Vec<Sample> = world_points
+        .iter()
+        .zip(&normalized_image_coordinates)
+        .map(|(world, image)| sample_conv(world.coords.into(), image.coords.into()))
+        .collect();
 
     // Estimate potential poses with P3P.
     // Arrsac should use the fourth point to filter and find only one model from the 4 generated.
@@ -52,65 +53,4 @@ fn arrsac() {
     // Compare the pose to ground truth.
     assert_relative_eq!(rot, pose.rotation, epsilon = EPSILON_APPROX);
     assert_relative_eq!(trans, pose.translation, epsilon = EPSILON_APPROX);
-}
-
-type V3 = (f32, f32, f32);
-
-/// This test is ignored because it is random and may fail in CI.
-/// Run `cargo test -- --ignored` to test it.
-#[quickcheck]
-fn non_degenerate_case(rot: V3, trans: V3, p1: V3, p2: V3, p3: V3, p4: V3) -> bool {
-    let mut arrsac = Arrsac::new(
-        Config::new(0.01).max_candidate_hypotheses(10),
-        SmallRng::from_seed([0; 16]),
-    );
-
-    // Use EPSILON_APPROX to force minimum distance.
-    let p1_cam = [p1.0, p1.1, EPSILON_APPROX + p1.2.abs()];
-    let p2_cam = [p2.0, p2.1, EPSILON_APPROX + p2.2.abs()];
-    let p3_cam = [p3.0, p3.1, EPSILON_APPROX + p3.2.abs()];
-    let p4_cam = [p4.0, p4.1, EPSILON_APPROX + p4.2.abs()];
-
-    // 2d keypoints
-    let p1_2d = Vector2::new(p1_cam[0], p1_cam[1]);
-    let p2_2d = Vector2::new(p2_cam[0], p2_cam[1]);
-    let p3_2d = Vector2::new(p3_cam[0], p3_cam[1]);
-    let p4_2d = Vector2::new(p4_cam[0], p4_cam[1]);
-    let p2ds = [p1_2d, p2_2d, p3_2d, p4_2d];
-
-    // Stop if the keypoint's location on the frame is too close.
-    for (a, b) in p2ds.iter().tuple_combinations() {
-        if (a - b).norm() < EPSILON_APPROX {
-            return true;
-        }
-    }
-
-    // Define the camera pose.
-    let rotation = UnitQuaternion::from_euler_angles(rot.0, rot.1, rot.2);
-    let translation = Translation::from(Vector3::new(trans.0, trans.1, trans.2));
-    let pose = Isometry3::from_parts(translation, rotation);
-
-    // Compute world coordinates.
-    let p1_world = (pose.inverse() * Point3::from(p1_cam)).coords.into();
-    let p2_world = (pose.inverse() * Point3::from(p2_cam)).coords.into();
-    let p3_world = (pose.inverse() * Point3::from(p3_cam)).coords.into();
-    let p4_world = (pose.inverse() * Point3::from(p4_cam)).coords.into();
-
-    let samples = [
-        sample_conv(p1_world, p1_cam),
-        sample_conv(p2_world, p2_cam),
-        sample_conv(p3_world, p3_cam),
-        sample_conv(p4_world, p4_cam),
-    ];
-
-    // Estimate potential poses with P3P.
-    // Arrsac should use the fourth point to filter and find only one model from the 4 generated.
-    let pose = arrsac
-        .model(&NordbergEstimator, &samples)
-        .unwrap()
-        .to_iso3();
-
-    // Compare the pose to ground truth.
-    relative_eq!(rotation, pose.rotation, epsilon = EPSILON_APPROX)
-        && relative_eq!(translation, pose.translation, epsilon = EPSILON_APPROX)
 }


### PR DESCRIPTION
This implements traits from `sample-consensus` and adds a test that shows that it is possible to estimate the pose using arrsac. It also fixes the degenerate case checking that is being used with quickcheck so that it succeeds seemingly 100% of the time for use in CI testing (which is now enabled).